### PR TITLE
Fix PDF links to use absolute URLs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,6 @@ Web エンジニアキャリアのスタート。親会社のリクルートの�
 - [【VSCode】ES6記法スニペットのEmmet展開方法まとめ](https://qiita.com/kiwatchi1991/items/75f337628b3cbd9a4e32)
 
 ## パーソナル
-- <a href="docs/personal/strengthsfinder.pdf" target="_blank" rel="noopener noreferrer">ストレングスファインダー</a>
+- <a href="https://wakidas.github.io/resume/strengthsfinder.pdf" target="_blank" rel="noopener noreferrer">ストレングスファインダー</a>
 - <a href="https://jobgram.jp/m/9f550899-d795-48c9-beb6-2ddfa95a79a2/result" target="_blank" rel="noopener noreferrer">ジョブグラム</a>
 - 趣味：読書、料理、DYI、電子工作、ギター、ファッション

--- a/src/content/resume/index.md
+++ b/src/content/resume/index.md
@@ -203,6 +203,6 @@ Web エンジニアキャリアのスタート。親会社のリクルートの�
 - [【VSCode】ES6記法スニペットのEmmet展開方法まとめ](https://qiita.com/kiwatchi1991/items/75f337628b3cbd9a4e32)
 
 ## パーソナル
-- <a href="/resume/strengthsfinder.pdf" target="_blank" rel="noopener noreferrer">ストレングスファインダー</a>
+- <a href="https://wakidas.github.io/resume/strengthsfinder.pdf" target="_blank" rel="noopener noreferrer">ストレングスファインダー</a>
 - <a href="https://jobgram.jp/m/9f550899-d795-48c9-beb6-2ddfa95a79a2/result" target="_blank" rel="noopener noreferrer">ジョブグラム</a>
 - 趣味：読書、料理、DYI、電子工作、ギター、ファッション


### PR DESCRIPTION
## Summary
- Fix strengthsfinder.pdf links to use absolute GitHub Pages URLs
- Ensure PDF links work correctly in all contexts including generated PDFs

## Changes
- Update docs/README.md: relative path → absolute URL
- Update src/content/resume/index.md: relative path → absolute URL  
- Both files now use https://wakidas.github.io/resume/strengthsfinder.pdf

## Problem solved
- PDF generation now includes working links to StrengthsFinder results
- Links work consistently across web and PDF formats

## Test plan
- [x] Links verified to work in browser
- [x] PDF generation tested with correct links
- [x] Both source files updated consistently

🤖 Generated with [Claude Code](https://claude.ai/code)