### PR TITLE
Restrict deploy action to main branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main, feature/astro-ssg-resume ]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove feature branch from GitHub Actions deploy triggers
- Ensure deployments only happen from main branch pushes

## Changes
- Update .github/workflows/deploy.yml
- Remove feature/astro-ssg-resume from push trigger branches
- Keep workflow_dispatch for manual testing when needed

## Benefits
- Prevents unnecessary deployments from feature branches
- Cleaner deployment workflow focused on production releases
- Manual dispatch still available for testing specific branches

🤖 Generated with [Claude Code](https://claude.ai/code)