### PR TITLE
Fix layout spacing and remove duplicate section titles

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run build:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/src/components/sections/BasicInfoSection.astro
+++ b/src/components/sections/BasicInfoSection.astro
@@ -6,14 +6,6 @@ const { Content } = await content.render();
 ---
 
 <section class="basic-info-section">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
-      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
-      </svg>
-    </div>
-    <h2 class="!m-0 !p-0 !bg-none !border-none !text-2xl">基本情報</h2>
-  </div>
   <Content />
 </section>
 

--- a/src/components/sections/MotivationSection.astro
+++ b/src/components/sections/MotivationSection.astro
@@ -6,14 +6,6 @@ const { Content } = await content.render();
 ---
 
 <section class="motivation-section">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
-      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
-      </svg>
-    </div>
-    <h2 class="!m-0 !p-0 !bg-none !border-none !text-2xl">志望動機</h2>
-  </div>
   <Content />
 </section>
 

--- a/src/components/sections/OutputSection.astro
+++ b/src/components/sections/OutputSection.astro
@@ -6,14 +6,6 @@ const { Content } = await content.render();
 ---
 
 <section class="output-section">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
-      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-      </svg>
-    </div>
-    <h2 class="!m-0 !p-0 !bg-none !border-none !text-2xl">アウトプット</h2>
-  </div>
   <Content />
 </section>
 

--- a/src/components/sections/PersonalSection.astro
+++ b/src/components/sections/PersonalSection.astro
@@ -6,14 +6,6 @@ const { Content } = await content.render();
 ---
 
 <section class="personal-section">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
-      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-      </svg>
-    </div>
-    <h2 class="!m-0 !p-0 !bg-none !border-none !text-2xl">パーソナル</h2>
-  </div>
   <Content />
 </section>
 

--- a/src/components/sections/SelfPRSection.astro
+++ b/src/components/sections/SelfPRSection.astro
@@ -6,14 +6,6 @@ const { Content } = await content.render();
 ---
 
 <section class="self-pr-section">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
-      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
-      </svg>
-    </div>
-    <h2 class="!m-0 !p-0 !bg-none !border-none !text-2xl">自己PR</h2>
-  </div>
   <Content />
 </section>
 

--- a/src/components/sections/WorkExperienceSection.astro
+++ b/src/components/sections/WorkExperienceSection.astro
@@ -6,14 +6,6 @@ const { Content } = await content.render();
 ---
 
 <section class="work-experience-section">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="w-8 h-8 bg-gradient-to-r from-green-500 to-green-600 rounded-lg flex items-center justify-center">
-      <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2-2v2m8 0H8m8 0v2a2 2 0 002 2v8a2 2 0 01-2 2H8a2 2 0 01-2-2v-8a2 2 0 012-2V8"></path>
-      </svg>
-    </div>
-    <h2 class="!m-0 !p-0 !bg-none !border-none !text-2xl">職務経歴</h2>
-  </div>
   <Content />
 </section>
 

--- a/src/layouts/ResumeLayout.astro
+++ b/src/layouts/ResumeLayout.astro
@@ -37,11 +37,11 @@ import '../styles/global.css';
 
     <style>
       :global(h1) {
-        @apply text-4xl font-bold bg-gradient-to-r from-green-400 to-green-600 bg-clip-text text-transparent mb-8 text-center;
+        @apply text-4xl font-bold bg-gradient-to-r from-green-400 to-green-600 bg-clip-text text-transparent mb-4 text-center;
       }
 
       :global(h2) {
-        @apply text-2xl font-bold text-gray-100 mt-10 mb-6 px-4 py-3 bg-gradient-to-r from-green-600/20 to-green-500/10 rounded-lg border-l-4 border-green-600;
+        @apply text-2xl font-bold text-gray-100 mt-4 mb-3 px-4 py-3 bg-gradient-to-r from-green-600/20 to-green-500/10 rounded-lg border-l-4 border-green-600;
       }
 
       :global(h3) {
@@ -55,7 +55,7 @@ import '../styles/global.css';
 
       /* Section styling */
       :global(section) {
-        @apply bg-gray-700/30 backdrop-blur-md rounded-2xl p-8 mb-8 
+        @apply bg-gray-700/30 backdrop-blur-md rounded-2xl p-6 mb-6 
                shadow-[0_4px_20px_rgba(0,0,0,0.3),0_0_0_1px_rgba(255,255,255,0.1),inset_0_1px_0_rgba(255,255,255,0.15)] 
                border border-gray-600/30 
                hover:shadow-[0_8px_40px_rgba(0,0,0,0.4),0_0_0_1px_rgba(34,197,94,0.2),inset_0_1px_0_rgba(255,255,255,0.2)] 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,8 +16,6 @@ const resume = await getEntry('resume', 'index');
   
   <BasicInfoSection />
   
-  <hr />
-  
   <WorkExperienceSection />
   
   <MotivationSection />


### PR DESCRIPTION
## Summary
• Remove redundant h2 titles from all section components to eliminate visual duplication
• Optimize spacing throughout the layout for better content density
• Improve visual hierarchy by using top tab-style design as primary section indicators

## Changes
- Remove h2 titles from all 6 section components (BasicInfo, WorkExperience, etc.)
- Reduce h2 spacing from mt-10 mb-6 to mt-4 mb-3
- Optimize section spacing from p-8 mb-8 to p-6 mb-6  
- Remove redundant hr separator

## Test plan
- [ ] Verify no duplicate titles appear
- [ ] Check improved spacing and content density
- [ ] Ensure visual hierarchy remains clear

🤖 Generated with [Claude Code](https://claude.ai/code)