### PR TITLE
Update personal blog description

### DIFF
--- a/src/components/sections/OutputSection.astro
+++ b/src/components/sections/OutputSection.astro
@@ -82,7 +82,7 @@ const outputData = [
     id: 'personal-blog',
     title: '個人ブログ',
     url: 'https://note.com/wakidas',
-    description: 'エンジニアリング、マネジメント、読書録など',
+    description: '読書録メイン',
     articles: [
       { 
         title: 'EMConf JP 2025 参加レポ', 


### PR DESCRIPTION
## Summary
Change personal blog description to be more concise and focused.

## Changes
- Update description from 'エンジニアリング、マネジメント、読書録など' to '読書録メイン'
- Better reflects the actual content focus of the blog