### PR TITLE
Add margin to company description paragraphs

### DIFF
--- a/src/components/sections/WorkExperienceSection.astro
+++ b/src/components/sections/WorkExperienceSection.astro
@@ -44,4 +44,9 @@ const { Content } = await content.render();
   .work-experience-section :global(p) {
     @apply mb-1;
   }
+  
+  /* 会社名直後の概要説明にマージンを追加 */
+  .work-experience-section :global(h3 + p) {
+    @apply my-4;
+  }
 </style>


### PR DESCRIPTION
## Summary
- 職歴セクションの各社概要説明の上下にマージンを追加
- 会社名（h3）直後の概要説明（p）に`my-4`クラスを適用
- 視認性と階層構造の明確化を実現

## Changes
- `WorkExperienceSection.astro`にCSSルールを追加
  - `h3 + p`セレクタで会社名直後の段落を特定
  - `my-4`でtop/bottomマージンを16px追加

## 対象箇所
- 株式会社ニジボックスの概要説明
- 株式会社ニチレイフーズの概要説明

## Test plan
- [ ] ローカルビルドで動作確認
- [ ] 各社の概要説明に適切なマージンが追加されることを確認
- [ ] 他の段落要素に影響がないことを確認
- [ ] レスポンシブデザインでの表示確認

Fixes #40

🤖 Generated with [Claude Code](https://claude.ai/code)