### PR TITLE
feat: Add monthly automatic deployment schedule (#22)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  schedule:
+    # 毎月1日の9:00 JST (毎月1日の0:00 UTC)に実行
+    - cron: '0 0 1 * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- 毎月1日の朝9:00 JST（0:00 UTC）に自動デプロイを実行するスケジュール設定を追加
- 既存のpushトリガーとworkflow_dispatch（手動実行）はそのまま維持

## Changes
- `.github/workflows/deploy.yml`にscheduleトリガーを追加
- cron式: `0 0 1 * *`（毎月1日の0:00 UTC = 9:00 JST）

## Why 9:00 JST?
- GitHub ActionsのcronはUTC基準
- 毎月1日の0:00 JSTは前月最終日の15:00 UTCとなり、月末日が可変（28-31日）のため設定が複雑
- 1日の9:00 JSTなら確実に毎月1日に実行可能

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)