### PR TITLE
feat: GitHub ActionsデプロイにSlack通知を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,3 +51,79 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      
+      - name: Notify Success to Slack
+        if: success()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "✅ デプロイが成功しました",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*✅ デプロイが成功しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* ${{ github.ref_name }}\n*コミット:* `${{ github.sha }}`\n*実行者:* ${{ github.actor }}\n*URL:* ${{ steps.deployment.outputs.page_url }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "サイトを確認"
+                      },
+                      "url": "${{ steps.deployment.outputs.page_url }}"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Actions詳細"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      
+      - name: Notify Failure to Slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "❌ デプロイが失敗しました",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*❌ デプロイが失敗しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* ${{ github.ref_name }}\n*コミット:* `${{ github.sha }}`\n*実行者:* ${{ github.actor }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Actions詳細を確認"
+                      },
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Summary
- GitHub Actionsのデプロイワークフローに成功/失敗時のSlack通知を追加
- デプロイの状況をリアルタイムで把握できるようになります

## Changes
- `deploy.yml`に2つの通知ステップを追加
  - 成功時: ✅ メッセージとデプロイ先URL、Actions詳細へのリンク
  - 失敗時: ❌ メッセージとActions詳細へのリンク
- `SLACK_WEBHOOK_URL`をGitHub Secretsに設定済み

## 通知内容
- リポジトリ名
- ブランチ名
- コミットハッシュ
- 実行者
- デプロイ先URL（成功時のみ）
- ボタンリンク（サイト確認、Actions詳細）

🤖 Generated with [Claude Code](https://claude.ai/code)