### PR TITLE
fix: Slack通知に@shimpei.wakidaメンションを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*✅ デプロイが成功しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* ${{ github.ref_name }}\n*コミット:* `${{ github.sha }}`\n*実行者:* ${{ github.actor }}\n*URL:* ${{ steps.deployment.outputs.page_url }}"
+                    "text": "<@shimpei.wakida> *✅ デプロイが成功しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* ${{ github.ref_name }}\n*コミット:* `${{ github.sha }}`\n*実行者:* ${{ github.actor }}\n*URL:* ${{ steps.deployment.outputs.page_url }}"
                   }
                 },
                 {
@@ -106,7 +106,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*❌ デプロイが失敗しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* ${{ github.ref_name }}\n*コミット:* `${{ github.sha }}`\n*実行者:* ${{ github.actor }}"
+                    "text": "<@shimpei.wakida> *❌ デプロイが失敗しました*\n\n*リポジトリ:* ${{ github.repository }}\n*ブランチ:* ${{ github.ref_name }}\n*コミット:* `${{ github.sha }}`\n*実行者:* ${{ github.actor }}"
                   }
                 },
                 {


### PR DESCRIPTION
## Summary
- Slack通知メッセージの先頭に@shimpei.wakidaメンションを追加
- 重要な通知を見逃さないようにするための改善

## Changes
- 成功時通知: `<@shimpei.wakida> ✅ デプロイが成功しました`
- 失敗時通知: `<@shimpei.wakida> ❌ デプロイが失敗しました`

🤖 Generated with [Claude Code](https://claude.ai/code)