### PR TITLE
feat: SEO/AIO/MLO対策とタイトル改善

### DIFF
--- a/src/layouts/ResumeLayout.astro
+++ b/src/layouts/ResumeLayout.astro
@@ -17,6 +17,23 @@ import '../styles/global.css';
     <title>{title}</title>
     {description && <meta name="description" content={description} />}
     
+    <!-- SEO/AIO/MLO Meta Tags -->
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description || "脇田慎平の職務経歴書。サーバーサイドエンジニアとしての経験とスキルをご紹介します。"} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://wakidas.github.io/resume/" />
+    <meta property="og:locale" content="ja_JP" />
+    
+    <!-- Twitter Card Tags -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description || "脇田慎平の職務経歴書。サーバーサイドエンジニアとしての経験とスキルをご紹介します。"} />
+    
+    <!-- Additional SEO Tags -->
+    <meta name="author" content="脇田慎平" />
+    <meta name="keywords" content="脇田慎平,職務経歴書,エンジニア,サーバーサイド,バックエンド,Python,Go,AWS,GCP" />
+    <link rel="canonical" href="https://wakidas.github.io/resume/" />
+    
     <!-- Modern Typography Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ import PersonalSection from '../components/sections/PersonalSection.astro';
 const resume = await getEntry('resume', 'index');
 ---
 
-<ResumeLayout title={resume.data.title} description={resume.data.description}>
+<ResumeLayout title="職務経歴書 🛠 脇田慎平" description={resume.data.description}>
   <h1>職務経歴書</h1>
   
   <BasicInfoSection />


### PR DESCRIPTION
## Summary
- ブラウザタブのタイトルを「職務経歴書 🛠 脇田慎平」に変更
- SEO/AIO/MLO対策として各種メタタグを追加
- Open Graph、Twitter Card、キーワード、作者情報などを設定

## Test plan
- [x] ローカルビルドが成功することを確認
- [ ] ブラウザタブに新しいタイトルが表示されることを確認
- [ ] デプロイ後、各種SEOツールでメタタグが正しく読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)