### PR TITLE
fix: アウトプットセクションのタイトルを左揃えに修正

### DIFF
--- a/src/components/sections/OutputSection.astro
+++ b/src/components/sections/OutputSection.astro
@@ -195,7 +195,7 @@ const outputData = [
 
 <style>
   .section-title {
-    @apply text-2xl font-bold text-gray-100 mb-8 text-center;
+    @apply text-2xl font-bold text-gray-100 mb-8;
   }
 
   .platforms-container {


### PR DESCRIPTION
## Summary
- 「アウトプット」セクションのタイトルが中央揃えになっていたのを左揃えに修正

## 変更内容
- `.section-title`クラスから`text-center`を削除

🤖 Generated with [Claude Code](https://claude.ai/code)