### PR TITLE
feat: GitHubスタイルのセクションアンカーリンク機能を追加

### DIFF
--- a/src/layouts/ResumeLayout.astro
+++ b/src/layouts/ResumeLayout.astro
@@ -198,5 +198,66 @@ import '../styles/global.css';
         }
       }
     </style>
+    
+    <script>
+      // 見出しと英語IDのマッピング
+      const headingMap = {
+        '基本情報': 'basic-info',
+        '職務経歴': 'work-experience',
+        '志望動機': 'motivation',
+        '自己PR': 'self-pr',
+        'アウトプット': 'output',
+        '個人情報': 'personal'
+      };
+
+      // DOMContentLoadedイベントでアンカーリンクを設定
+      document.addEventListener('DOMContentLoaded', function() {
+        // すべてのh2要素を取得
+        const headings = document.querySelectorAll('h2');
+        
+        headings.forEach((heading) => {
+          const headingText = heading.textContent.trim();
+          const id = headingMap[headingText];
+          
+          if (id) {
+            // IDを設定
+            heading.id = id;
+            
+            // アンカーリンクを作成
+            const anchor = document.createElement('a');
+            anchor.href = `#${id}`;
+            anchor.className = 'anchor-link';
+            anchor.innerHTML = '🔗';
+            anchor.setAttribute('aria-label', `${headingText}へのリンク`);
+            
+            // クリックイベントを追加
+            anchor.addEventListener('click', function(e) {
+              e.preventDefault();
+              
+              // URLを更新
+              history.pushState(null, null, `#${id}`);
+              
+              // スムーズスクロール
+              heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
+            
+            // 見出しの先頭に追加
+            heading.insertBefore(anchor, heading.firstChild);
+          }
+        });
+        
+        // ページ読み込み時にハッシュがある場合の処理
+        if (window.location.hash) {
+          const targetId = window.location.hash.slice(1);
+          const targetElement = document.getElementById(targetId);
+          
+          if (targetElement) {
+            setTimeout(() => {
+              targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, 100);
+          }
+        }
+      });
+    </script>
   </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,63 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* スムーズスクロール */
+html {
+  scroll-behavior: smooth;
+}
+
+/* セクション見出しのアンカーリンクスタイル */
+h2 {
+  position: relative;
+  scroll-margin-top: 2rem;
+}
+
+h2 .anchor-link {
+  position: absolute;
+  left: -1.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  color: #10b981;
+  text-decoration: none;
+  font-size: 1.2rem;
+  padding: 0.25rem;
+}
+
+h2:hover .anchor-link,
+h2 .anchor-link:focus {
+  opacity: 0.7;
+}
+
+h2 .anchor-link:hover {
+  opacity: 1;
+}
+
+/* モバイルでは常に表示 */
+@media (max-width: 768px) {
+  h2 .anchor-link {
+    opacity: 0.5;
+    left: -1.2rem;
+    font-size: 1rem;
+  }
+}
+
+/* ハッシュリンクでジャンプした時のハイライトアニメーション */
+h2:target {
+  animation: highlight 2s ease;
+}
+
+@keyframes highlight {
+  0% {
+    background-color: rgba(16, 185, 129, 0.2);
+    padding-left: 1rem;
+    margin-left: -1rem;
+  }
+  100% {
+    background-color: transparent;
+    padding-left: 0;
+    margin-left: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- GitHubのようなセクションアンカーリンク機能を実装
- 各セクション見出しにホバー時にリンクアイコン（🔗）を表示
- クリックでURLハッシュを更新してセクションへの直接リンクが可能に

## 実装内容

### CSSの追加（global.css）
- スムーズスクロールの設定
- ホバー時のリンクアイコン表示
- ターゲット時のハイライトアニメーション
- モバイル対応（常時表示）

### JavaScriptの実装（ResumeLayout.astro）
- 日本語見出しから英語IDへのマッピング
  - 基本情報 → `#basic-info`
  - 職務経歴 → `#work-experience`
  - 志望動機 → `#motivation`
  - 自己PR → `#self-pr`
  - アウトプット → `#output`
  - 個人情報 → `#personal`
- アンカーリンクの動的生成
- クリック時のURL更新とスムーズスクロール

## 動作確認
- 見出しホバーでリンクアイコン表示 ✓
- クリックでURLハッシュ更新 ✓
- スムーズスクロール動作 ✓
- ページリロード時のハッシュジャンプ ✓

🤖 Generated with [Claude Code](https://claude.ai/code)